### PR TITLE
fix: preact-iso peer dep version

### DIFF
--- a/packages/wmr/package.json
+++ b/packages/wmr/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "preact": "^10.5.12",
-    "preact-iso": "^1.0.0",
+    "preact-iso": ">=1.0.0 <3",
     "twind": ">=0.15.9 <2",
     "typescript": "^4.1.0"
   },


### PR DESCRIPTION
`preact-iso` v2 is now out and the default with WMR. [The major change was related to the router's route params](https://github.com/preactjs/wmr/releases/tag/preact-iso%402.0.0), so nothing impacted here. Safe to allow v1 & 2.