### PR TITLE
fix: prerender not awaiting sheet reset

### DIFF
--- a/packages/wmr/prerender.ts
+++ b/packages/wmr/prerender.ts
@@ -22,7 +22,7 @@ export default function prerenderWithTwind(
   // Ensure to start a new async scope
   return (data) =>
     Promise.resolve().then(async () => {
-      sheet.reset()
+      await sheet.reset()
 
       let { html, ...rest } = await prerender(render(data), options)
 


### PR DESCRIPTION
Fixes #17 

The issue I was running into was when multiple links lead to the same content. Say neither `/foo` nor `/bar` existed, so both urls would lead to a 404 page.

`/foo` (the 404 page) would have the correct styles, but `/bar` would not. `/bar` would be missing the content specific to the 404 page, but oddly, not the global styles (like header, page background, etc. Still not entirely sure why this is, but I'm not curious enough to go looking).

Finally realized it was the sheet only finishing it's reset after the next page had been prerendered. Just needed to insert an `await` to ensure the reset finished before prerendering the next page, else any common / shared styles would be removed.