### PR TITLE
[@twind/next] Update package.json to support Next12

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -32,7 +32,7 @@
   "// These are relative from within the dist/ folder": "",
   "sideEffects": false,
   "peerDependencies": {
-    "next": "10.x || 11.x",
+    "next": "10.x || 11.x || 12.x",
     "react": "^16.6.0 || ^17",
     "twind": ">=0.15.9 <2",
     "typescript": "^4.1.0"


### PR DESCRIPTION
This PR is in reference to issue #22, where NextJS 12 needs to be added as a peer dependency to `@twind/next` to be installed correctly.

Going by the NextJS upgrade guide here: https://nextjs.org/docs/upgrading, the minimum Node version may also have to be bumped up to `12.22.0`, although I'm guessing that's more on the end-user of this library to worry about.