### PR TITLE
WMR: Inject prerendered styles into the head, rather than body

### DIFF
--- a/packages/wmr/prerender.ts
+++ b/packages/wmr/prerender.ts
@@ -7,7 +7,7 @@ import prerender from 'preact-iso/prerender'
 
 import type { Configuration } from 'twind'
 import type { TwindPreactConfiguration } from '@twind/preact'
-import { asyncVirtualSheet, getStyleTag } from 'twind/server'
+import { asyncVirtualSheet, getStyleTagProperties } from 'twind/server'
 import { setup } from '@twind/preact'
 
 export default function prerenderWithTwind(
@@ -24,8 +24,14 @@ export default function prerenderWithTwind(
     Promise.resolve().then(async () => {
       await sheet.reset()
 
-      let { html, ...rest } = await prerender(render(data), options)
+      const result = await prerender(render(data), options)
+      const { id, textContent: children } = getStyleTagProperties(sheet)
 
-      return { ...rest, html: getStyleTag(sheet) + html }
+      return {
+        ...result,
+        head: {
+          elements: new Set([{ type: 'style', props: { id, children } }])
+        },
+      }
     })
 }


### PR DESCRIPTION
A little ways back WMR gained an API for being able to alter `<head>` information from prerender. A few examples can be found here: https://wmr.dev/docs/prerendering

This switches over the WMR integration to use this, rather than prepending the style tag to the `<body>` as used to be required.